### PR TITLE
Quest plus es6

### DIFF
--- a/Example_1stim_1psy_2resp_Watson(2017).html
+++ b/Example_1stim_1psy_2resp_Watson(2017).html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script src="./numeric.js"></script>
-        <script src="src/jsQuestPlus.js"></script>
+        <script src="./numeric.js"></script> -->
+        <script src="./dist/jsQuestPlus.js"></script>
     </head>
 <body>
     <p>This program simulates the example for estimation of contrast threshold {1, 1, 2} in <a href="https://doi.org/10.1167/17.3.10">Watson (2017)</a>.</p>
@@ -21,7 +21,7 @@
         // const tmp = slope * (stim - threshold)/20
         // return lapse - (guess + lapse -1)*Math.exp(-Math.pow(10, tmp))
 
-        return jsquest.weibull(stim, threshold, slope, guess, lapse) 
+        return jsQuestPlus.weibull(stim, threshold, slope, guess, lapse) 
     }
 
     // Psychometric function corresponding to the second response (response = 1).
@@ -40,8 +40,8 @@
     const simulated_answers = [1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     const simulated_stim = [-18, -22, -25, -28, -30, -22, -13, -15, -16, -18, -19, -20, -21, -22, -23, -19, -20, -20, -18, -18, -19, -17, -17, -18, -18, -18, -19, -19, -19, -19, -19, -19]
 
-    // jsqp means jsQuestPlus. You can use any variable name you like.
-    const jsqp = new jsquest(
+    // jsqp means jsQuestPlusPlus. You can use any variable name you like.
+    const jsqp = new jsQuestPlus(
         [func_resp0, func_resp1], [contrast_samples], [threshold_samples, slope, guess, lapse])
 
     console.log(jsqp)

--- a/Example_2stim_3psy_2resp_Watson(2017).html
+++ b/Example_2stim_3psy_2resp_Watson(2017).html
@@ -3,7 +3,7 @@
     <head>
         <script src="https://www.hes.kyushu-u.ac.jp/~kurokid/QUEST/dist/jsQUEST.js"></script>
         <script src="./numeric.js"></script>
-        <script src="src/jsQuestPlus.js"></script>
+        <script src="dist/jsQuestPlus.js"></script>
     </head>
 <body>
     <p>This program simulates the example for Contrast sensitivity function {2, 3, 2} in <a href="https://doi.org/10.1167/17.3.10">Watson (2017)</a>.</p>
@@ -25,7 +25,7 @@
     // You can specify the function or use the weibull/normcdf function jsQuest provides.
     function func_resp0(freq, contrast, threshold, c0, cf){
         const max = Math.max(threshold, c0 + cf*freq)
-        return jsquest.weibull(contrast, max, 3, 0.5, 0.01)
+        return jsQuestPlus.weibull(contrast, max, 3, 0.5, 0.01)
     }
 
     // Psychometric function corresponding to the second response (response = 1).
@@ -33,11 +33,11 @@
         return 1 - func_resp0(freq, contrast, threshold, c0, cf) 
     }
 
-    const spatial_frequency = jsquest.getArray_with_fix_interval(0, 2, 40) // [0, 2, 4, ..., 38, 40]
-    const contrast = jsquest.getArray_with_fix_interval(-50, 2, 0) // [-50, -48, -46, ..., -2, 0]
-    const threshold = jsquest.getArray_with_fix_interval(-50, 2, -30) // [-50, -48, -46, ..., -32, -30]
-    const c0 = jsquest.getArray_with_fix_interval(-60, 2, -40) // [-60, -58, -56, ..., -42, -40]
-    const cf = jsquest.getArray_with_fix_interval(0.8, 0.2, 1.6) // [0.8, 1, 1.2, 1.4, 1.6]
+    const spatial_frequency = jsQuestPlus.getArray_with_fix_interval(0, 2, 40) // [0, 2, 4, ..., 38, 40]
+    const contrast = jsQuestPlus.getArray_with_fix_interval(-50, 2, 0) // [-50, -48, -46, ..., -2, 0]
+    const threshold = jsQuestPlus.getArray_with_fix_interval(-50, 2, -30) // [-50, -48, -46, ..., -32, -30]
+    const c0 = jsQuestPlus.getArray_with_fix_interval(-60, 2, -40) // [-60, -58, -56, ..., -42, -40]
+    const cf = jsQuestPlus.getArray_with_fix_interval(0.8, 0.2, 1.6) // [0.8, 1, 1.2, 1.4, 1.6]
 
     // These values are written in Watson (2017)
     // Note that, in Watson (2017), the first answer corresponds to 1 and the second answer to 2.
@@ -47,7 +47,7 @@
         [18, -26], [40, 0], [18, -26], [0, -32], [0, -32], [0, -34], [0, -34], [40, 0], [18, -26], [38, 0], [18, -26]]
 
     // jsqp means jsQuestPlus. You can use any variable name you like.
-    const jsqp = new jsquest([func_resp0, func_resp1], [spatial_frequency, contrast], [threshold, c0, cf])
+    const jsqp = new jsQuestPlus([func_resp0, func_resp1], [spatial_frequency, contrast], [threshold, c0, cf])
     console.log(jsqp)
 
     console.log(simulated_answers.length)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 
 export default [
-  // jsQUEST.js can be imported with a script tag or via require)
+  // jsQUEST.js can be imported with a script tag or via require
   {
     input: 'src/jsQUEST.js',
     output: {
@@ -28,5 +28,36 @@ export default [
       nodeResolve(),
       sourcemaps()
     ]
+  },
+  // jsQuestPlus.js can be imported with a script tag or via require
+  {
+    input: 'src/jsQuestPlus.js',
+    output: {
+      format: 'umd',
+      name: 'jsQuestPlus',
+      globals: {
+        numeric$1: 'numeric'
+      },
+      file: 'dist/jsQuestPlus.js',
+      sourcemap: true
+    },
+    plugins: [
+      nodeResolve(),
+      sourcemaps()
+    ]
+  },
+  // jsQuestPlus.module.js can be imported as an ES module
+  {
+    input: 'src/jsQuestPlus.js',
+    output: {
+      format: 'es',
+      file: 'dist/jsQuestPlus.module.js',
+      sourcemap: true
+    },
+    plugins: [
+      nodeResolve(),
+      sourcemaps()
+    ]
   }
+
 ];

--- a/src/jsQuestPlus.js
+++ b/src/jsQuestPlus.js
@@ -3,6 +3,7 @@
 //  https://github.com/BrainardLab/mQUESTPlus
 // Kudos to the developers!
 // 
+import numeric from 'numeric_es6';
 /* global numeric */
 
 console.log('jsQuestPlus Version 0.1')
@@ -359,3 +360,5 @@ class jsquest {
     // end    
 
 }
+
+export default jsquest;


### PR DESCRIPTION
This PR lets rollup create bundles for jsQuestPlus. The two examples are updated to use the bundled versions of jsQuestPlus.